### PR TITLE
EF-23266: strip domain from email-as-name to avoid display-name imper…

### DIFF
--- a/apps/OpenSignServer/cloud/parsefunction/sendMailv3.js
+++ b/apps/OpenSignServer/cloud/parsefunction/sendMailv3.js
@@ -93,8 +93,9 @@ async function sendMailProvider(req, plan, monthchange) {
         }
         const originalFrom = req.params.from || '';
         const fromName = (req.params.fromName || '').replace(/[<>\r\n"]/g, '').trim() || undefined;
+        const displayName = fromName?.includes('@') ? fromName.split('@')[0] : fromName;
         const from = fromName
-          ? `"${fromName} via EffiSign" <sign@effi.com.au>`
+          ? `"${displayName} via EffiSign" <sign@effi.com.au>`
           : originalFrom;
         const replyTo = fromName ? originalFrom : undefined;
 
@@ -177,8 +178,9 @@ async function sendMailProvider(req, plan, monthchange) {
     } else {
       const originalFrom = req.params.from || '';
       const fromName = (req.params.fromName || '').replace(/[<>\r\n"]/g, '').trim() || undefined;
+      const displayName = fromName?.includes('@') ? fromName.split('@')[0] : fromName;
       const from = fromName
-        ? `"${fromName} via EffiSign" <sign@effi.com.au>`
+        ? `"${displayName} via EffiSign" <sign@effi.com.au>`
         : originalFrom;
       const replyTo = fromName ? originalFrom : undefined;
 


### PR DESCRIPTION


If a user's Name field contains an email address, use only the local part (before @) as the display name. Prevents email security tools from flagging the message for display-name spoofing when the From display name contains an @ that doesn't match the sending address.